### PR TITLE
Update to Node 18

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ references:
     &container_config_node
     working_directory: ~/project/build
     docker:
-      - image: cimg/node:16.14
+      - image: cimg/node:18.16
 
   workspace_root: &workspace_root ~/project
 
@@ -72,7 +72,7 @@ jobs:
       - run:
           name: Checkout next-ci-shared-helpers
           command: git clone --depth 1
-            git@github.com:Financial-Times/next-ci-shared-helpers.git
+            git@github.com:Financial-Times/next-ci-shared-helpers.git --branch unpin-heroku
             .circleci/shared-helpers
       - *restore_npm_cache
       - run:

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,8 @@
         "snyk": "^1.167.2"
       },
       "engines": {
-        "node": "16.x"
+        "node": "16.x || 18.x",
+        "npm": "7.x || 8.x || 9.x"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "snyk": "^1.167.2"
   },
   "engines": {
-    "node": "16.x"
+    "node": "16.x || 18.x",
+    "npm": "7.x || 8.x || 9.x"
   },
   "snyk": true,
   "husky": {
@@ -29,5 +30,8 @@
       "commit-msg": "secret-squirrel-commitmsg",
       "pre-commit": "secret-squirrel"
     }
+  },
+  "volta": {
+    "node": "18.16.0"
   }
 }


### PR DESCRIPTION
Automatically ran via Platforms' [migration script](https://github.com/Financial-Times/platform-scripts/blob/464d56876a27742dbdee2713a31266cc268ebfe3/upgrade-node-18/upgrade-node-18.ts)